### PR TITLE
Make the API_ROOT configurable with an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For convenience, we have a live API server running at https://conduit.production
 
 The source code for the backend server (available for Node, Rails and Django) can be found in the [main RealWorld repo](https://github.com/gothinkster/realworld).
 
-If you want to change the API URL to a local server, simply edit `src/agent.js` and change `API_ROOT` to the local server's URL (i.e. `http://localhost:3000/api`)
+If you want to change the API URL to a local server, start/build the app with the REACT_APP_BACKEND_URL environment variable pointing to the local server's URL (i.e. `REACT_APP_BACKEND_URL="http://localhost:3000/api" npm run build`)
 
 
 ## Functionality overview

--- a/src/agent.js
+++ b/src/agent.js
@@ -3,7 +3,7 @@ import _superagent from 'superagent';
 
 const superagent = superagentPromise(_superagent, global.Promise);
 
-const API_ROOT = 'https://conduit.productionready.io/api';
+const API_ROOT = process.env.REACT_APP_BACKEND_URL || 'https://conduit.productionready.io/api';
 
 const encode = encodeURIComponent;
 const responseBody = res => res.body;


### PR DESCRIPTION
Using an environment variable makes it easier to configure the backend URL build-time. This change adds support for setting the API_ROOT for the build/start commands.

It uses react-app's environment variable handler: https://create-react-app.dev/docs/adding-custom-environment-variables/