### PR TITLE
Fix missing image in Header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -57,7 +57,7 @@ const LoggedInView = React.memo(props => {
           <Link
             to={`/@${props.currentUser.username}`}
             className="nav-link">
-            <img src={props.currentUser || 'https://static.productionready.io/images/smiley-cyrus.jpg'} className="user-pic" alt={props.currentUser.username} />
+            <img src={props.currentUser.image || 'https://static.productionready.io/images/smiley-cyrus.jpg'} className="user-pic" alt={props.currentUser.username} />
             {props.currentUser.username}
           </Link>
         </li>


### PR DESCRIPTION
The header shows a missing image even when there is one set for the current user.

See:

![image](https://user-images.githubusercontent.com/82075/107847311-bf0ce400-6dea-11eb-91e9-bc912ad4fc04.png)

The component tries to show the whole user object and not just the profile image. This change fixes that.