### PR TITLE
Fix redirect handling on failed login

### DIFF
--- a/src/features/auth/AuthScreen.js
+++ b/src/features/auth/AuthScreen.js
@@ -50,12 +50,16 @@ function AuthScreen({ isRegisterScreen }) {
       isRegisterScreen
         ? register({ username, email, password })
         : login({ email, password })
-    );
-    if (isRegisterScreen) {
-      navigate('/login');
-    } else {
-      navigate('/');
-    }
+    ).then((action) => {
+      if (action.meta.requestStatus === 'rejected') {
+        return;
+      }
+      if (isRegisterScreen) {
+        navigate('/login');
+      } else {
+        navigate('/');
+      }
+    });
   };
 
   return (


### PR DESCRIPTION
Before: user is redirected to home route after failed sign in attempt

https://github.com/khaledosman/react-redux-realworld-example-app/assets/45208632/f64894bd-401d-4fbc-bc1d-c312deecd529


After: user stays on auth screen after failed sign in attempt

https://github.com/khaledosman/react-redux-realworld-example-app/assets/45208632/10503173-2d36-4b62-a097-e1d34d94018c

